### PR TITLE
experiment: making ROSA CLI more unit testable

### DIFF
--- a/cmd/create/kubeletconfig/cmd2.go
+++ b/cmd/create/kubeletconfig/cmd2.go
@@ -1,0 +1,142 @@
+/*
+Copyright (c) 2023 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kubeletconfig
+
+import (
+	"context"
+	"fmt"
+	"github.com/openshift/rosa/pkg/interactive/confirm"
+	"os"
+
+	"github.com/spf13/cobra"
+
+	"github.com/openshift/rosa/pkg/interactive"
+	. "github.com/openshift/rosa/pkg/kubeletconfig"
+	"github.com/openshift/rosa/pkg/ocm"
+	"github.com/openshift/rosa/pkg/rosa"
+)
+
+// RosaCommandRun defines a function that should be returned to implement the actual action of the command
+type RosaCommandRun func(ctx context.Context, r *rosa.Runtime, command *cobra.Command, args []string) error
+
+// RosaRuntimeVisitor defines a function that can visit the Runtime and configure it as required. Default implementation
+// of this would exist to facilitate the most common scenarios e.g with OCM only
+type RosaRuntimeVisitor func(ctx context.Context, r *rosa.Runtime, command *cobra.Command, args []string) error
+
+// This is the default runnable function for all commands. It takes care of instantiating the runtime and context
+// and then invokes the runtime visitor and finally, the commandrun.
+func DefaultRosaCommandRun(visitor RosaRuntimeVisitor, commandRun RosaCommandRun) func(command *cobra.Command, args []string) {
+	return func(command *cobra.Command, args []string) {
+		ctx := context.Background()
+		runtime := rosa.NewRuntime()
+		defer runtime.Cleanup()
+
+		err := visitor(ctx, runtime, command, args)
+		if err != nil {
+			runtime.Reporter.Errorf(err.Error())
+			os.Exit(1)
+		}
+
+		err = commandRun(ctx, runtime, command, args)
+		if err != nil {
+			runtime.Reporter.Errorf(err.Error())
+			os.Exit(1)
+		}
+	}
+}
+
+// Return the command fully initialised, but not globally scoped within the package
+func CreateKubeletConfig() *cobra.Command {
+
+	options := NewKubeletConfigOptions()
+
+	cmd := &cobra.Command{
+		Use:     "kubeletconfig",
+		Aliases: []string{"kubelet-config"},
+		Short:   "Create a custom kubeletconfig for a cluster",
+		Long:    "Create a custom kubeletconfig for a cluster",
+		Example: `  # Create a custom kubeletconfig with a pod-pids-limit of 5000
+  rosa create kubeletconfig --cluster=mycluster --pod-pids-limit=5000
+  `,
+		Run: DefaultRosaCommandRun(CreateKubeletConfigRuntimeVisitor(), CreateKubeletConfigRun(options)),
+	}
+
+	flags := cmd.Flags()
+	flags.SortFlags = false
+	flags.IntVar(
+		&options.PodPidsLimit,
+		PodPidsLimitOption,
+		PodPidsLimitOptionDefaultValue,
+		PodPidsLimitOptionUsage)
+
+	ocm.AddClusterFlag(cmd)
+	interactive.AddFlag(flags)
+	return cmd
+}
+
+// Visitor function that customises the runtime for this command
+func CreateKubeletConfigRuntimeVisitor() RosaRuntimeVisitor {
+	return func(ctx context.Context, r *rosa.Runtime, command *cobra.Command, args []string) error {
+		r.WithOCM()
+		return nil
+	}
+}
+
+// The actual logic of the command. os.Exit is not allowed during the execution of this function.
+// errors are bubbled upwards and handled centrally.
+func CreateKubeletConfigRun(options KubeletConfigOptions) RosaCommandRun {
+	return func(ctx context.Context, r *rosa.Runtime, command *cobra.Command, args []string) error {
+
+		client := NewKubeletConfigClient(ctx, r)
+		_, err := client.CanCreateKubeletConfig(r.ClusterKey)
+		if err != nil {
+			return err
+		}
+
+		// Interactive mode is a function of the cobra layer and not ROSA core
+		if options.PodPidsLimit == PodPidsLimitOptionDefaultValue && !interactive.Enabled() {
+			interactive.Enable()
+			r.Reporter.Infof("Enabling interactive mode")
+			options.PodPidsLimit, err = interactive.GetInt(GetInteractiveInput(MaxPodPidsLimit, nil))
+			if err != nil {
+				return err
+			}
+		}
+
+		// Could also be delegated to the KubeletConfigClient
+		err = options.Validate(ctx, r)
+		if err != nil {
+			return err
+		}
+
+		prompt := fmt.Sprintf("Creating the custom KubeletConfig for cluster '%s' will cause all non-Control Plane "+
+			"nodes to reboot. This may cause outages to your applications. Do you wish to continue?", r.ClusterKey)
+
+		if confirm.ConfirmRaw(prompt) {
+
+			_, err = client.CreateKubeletConfig(r.ClusterKey, options)
+			if err != nil {
+				return err
+			}
+
+			r.Reporter.Infof("Successfully created custom KubeletConfig for cluster '%s'", r.ClusterKey)
+		}
+
+		r.Reporter.Infof("Creation of custom KubeletConfig for cluster '%s' aborted.", r.ClusterKey)
+		return nil
+	}
+}

--- a/pkg/kubeletconfig/client.go
+++ b/pkg/kubeletconfig/client.go
@@ -1,0 +1,44 @@
+package kubeletconfig
+
+import (
+	"context"
+	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
+	"github.com/openshift/rosa/pkg/ocm"
+	"github.com/openshift/rosa/pkg/rosa"
+)
+
+type KubeletConfigClient interface {
+	CanCreateKubeletConfig(clusterId string) (bool, error)
+	GetKubeletConfig(clusterId string) (*cmv1.KubeletConfig, error)
+	CreateKubeletConfig(clusterId string, options KubeletConfigOptions) (*cmv1.KubeletConfig, error)
+	UpdateKubeletConfig(clusterId string, options KubeletConfigOptions) (*cmv1.KubeletConfig, error)
+	DeleteKubeletConfig(clusterId string, options KubeletConfigOptions) (*cmv1.KubeletConfig, error)
+}
+
+type KubeletConfigClientImpl struct {
+	ocm *ocm.Client
+}
+
+func NewKubeletConfigClient(_ context.Context, runtime *rosa.Runtime) KubeletConfigClient {
+	return &KubeletConfigClientImpl{ocm: runtime.OCMClient}
+}
+
+func (k KubeletConfigClientImpl) CanCreateKubeletConfig(clusterId string) (bool, error) {
+	panic("implement me")
+}
+
+func (k KubeletConfigClientImpl) GetKubeletConfig(clusterId string) (*cmv1.KubeletConfig, error) {
+	panic("implement me")
+}
+
+func (k KubeletConfigClientImpl) CreateKubeletConfig(clusterId string, options KubeletConfigOptions) (*cmv1.KubeletConfig, error) {
+	panic("implement me")
+}
+
+func (k KubeletConfigClientImpl) UpdateKubeletConfig(clusterId string, options KubeletConfigOptions) (*cmv1.KubeletConfig, error) {
+	panic("implement me")
+}
+
+func (k KubeletConfigClientImpl) DeleteKubeletConfig(clusterId string, options KubeletConfigOptions) (*cmv1.KubeletConfig, error) {
+	panic("implement me")
+}

--- a/pkg/kubeletconfig/options.go
+++ b/pkg/kubeletconfig/options.go
@@ -1,0 +1,35 @@
+package kubeletconfig
+
+import (
+	"context"
+	"fmt"
+	"github.com/openshift/rosa/pkg/rosa"
+)
+
+type KubeletConfigOptions struct {
+	PodPidsLimit int
+}
+
+func NewKubeletConfigOptions() *KubeletConfigOptions {
+	return &KubeletConfigOptions{}
+}
+
+// Validate that the options the user has selected are correct
+func (k *KubeletConfigOptions) Validate(_ context.Context, runtime *rosa.Runtime) error {
+	maxPidsLimit, err := GetMaxPidsLimit(runtime.OCMClient)
+	if err != nil {
+		return fmt.Errorf("Failed to check maximum allowed Pids limit for cluster '%s'",
+			runtime.ClusterKey)
+	}
+
+	if k.PodPidsLimit < MinPodPidsLimit {
+		return fmt.Errorf("The minimum value for --pod-pids-limit is '%d'. You have supplied '%d'",
+			MinPodPidsLimit, k.PodPidsLimit)
+	}
+
+	if k.PodPidsLimit > maxPidsLimit {
+		return fmt.Errorf("The maximum value for --pod-pids-limit is '%d'. You have supplied '%d'",
+			maxPidsLimit, k.PodPidsLimit)
+	}
+	return nil
+}


### PR DESCRIPTION
This PR is an example for discussion on how we can make ROSA CLI more testable by introducing clear layers of separation.

In this example, we re-write the `rosa create kubeletconfig` command to try and utilise layers of separation. Specifically we:

- Centralise handling of runtime and context instantiation and cleanup
- Provide interfaces for dealing with OCM in an opinionated manner to create the KubeletConfig
- Provide validation of options entered by the user when creating their KubeletConfig
- Ensure that input/output in the context of the CLI remains within the Cobra framework.

